### PR TITLE
Potential fix for code scanning alert no. 279: Clear-text logging of sensitive information

### DIFF
--- a/dronecore/dji_adapter.py
+++ b/dronecore/dji_adapter.py
@@ -398,7 +398,7 @@ class DJIAdapter(FlightControllerAdapter):
                 return True
             elif command_name == "set_precision_landing":
                 enabled = parameters.get("enabled", True)
-                logger.info(f"Setting precision landing to {enabled}")
+                logger.info("Setting precision landing feature")
                 self._precision_landing_enabled = enabled
                 return True
 


### PR DESCRIPTION
Potential fix for [https://github.com/BuloZB/BuloCloudSentinel/security/code-scanning/279](https://github.com/BuloZB/BuloCloudSentinel/security/code-scanning/279)

To fix the issue, we will sanitize the logging statement to avoid directly logging untrusted data. Instead of logging the raw value of `enabled`, we will log a generic message indicating the action being performed without including the specific value. This approach ensures that sensitive or untrusted data is not exposed in the logs while still providing useful operational information.

Changes required:
1. Modify the logging statement on line 401 in `dronecore/dji_adapter.py` to exclude the value of `enabled`.
2. Ensure that the logging statement provides sufficient context for debugging without exposing sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
